### PR TITLE
Expose pagination outside the project

### DIFF
--- a/Vox/Core/Networking/Extensions/Pagination.swift
+++ b/Vox/Core/Networking/Extensions/Pagination.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-struct Pagination {
+public struct Pagination {
     
 }


### PR DESCRIPTION
When using library in my project I was not able to use `PageBased` pagination class. 
Problem is that `PageBased` class declared `public`, but it is nested inside `Pagination` struct which is implicitly `internal`.  
To get access to `PageBased` class I make `Pagination` struct `public`.